### PR TITLE
Add support for Vault KV engine version 2

### DIFF
--- a/pkg/providers/vault/vault.go
+++ b/pkg/providers/vault/vault.go
@@ -78,7 +78,17 @@ func (p *provider) GetStringMap(key string) (map[string]interface{}, error) {
 		return nil, fmt.Errorf("no secret found for path %q", key)
 	}
 
-	for k, v := range secret.Data {
+	// Vault KV Version 1
+	secrets := secret.Data
+
+	// Vault KV Version 2
+	if _, ok := secret.Data["data"]; ok {
+		if m, ok := secret.Data["data"].(map[string]interface{}); ok {
+			secrets = m
+		}
+	}
+
+	for k, v := range secrets {
 		res[k] = fmt.Sprintf("%v", v)
 	}
 


### PR DESCRIPTION
There are two versions of [Vault KV engine](https://www.vaultproject.io/docs/secrets/kv/index.html).
Vault KV engine version 2 (which is enabled by default on vault cluster creation under `secret/` path) has a bit different response format:
v1: https://www.vaultproject.io/api/secret/kv/kv-v1.html#sample-response
VS
v2: https://www.vaultproject.io/api/secret/kv/kv-v2.html#sample-response-1

Example:
```bash
# kv v1
$ vault secrets enable -path=kvv1 kv
Success! Enabled the kv secrets engine at: kvv1/

$ vault write kvv1/aaa/mysecret abc=xxx
Success! Data written to: kvv1/aaa/mysecret

$ vault write kvv1/data qwerty=123
Success! Data written to: kvv1/data

# kv v2
$ vault secrets enable -path=kvv2 -version=2 kv
Success! Enabled the kv secrets engine at: kvv2/

$ vault kv put kvv2/foo/bar abc=xyz bcd=123
Key              Value
---              -----
created_time     2019-10-08T05:21:37.003754Z
deletion_time    n/a
destroyed        false
version          1

# eval
echo 'values: 
- a: ref+vault://127.0.0.1:8200/kvv1/aaa/mysecret?proto=http#/abc
- b: ref+vault://127.0.0.1:8200/kvv1/data?proto=http#/qwerty
- c: ref+vault://127.0.0.1:8200/kvv2/data/foo/bar?proto=http#/abc' | bin/vals eval -f -

values:
  - a: xxx
  - b: "123"
  - c: xyz
```

