### PR TITLE
vault provider: add ability to retrieve token from ~/.vault-token file

### DIFF
--- a/pkg/providers/vault/vault.go
+++ b/pkg/providers/vault/vault.go
@@ -3,6 +3,7 @@ package vault
 import (
 	"fmt"
 	"github.com/mumoshu/vals/pkg/api"
+	"io/ioutil"
 	"os"
 	"strings"
 
@@ -107,6 +108,17 @@ func (p *provider) ensureClient() (*vault.Client, error) {
 		if err != nil {
 			p.debugf("Vault connections failed")
 			return nil, fmt.Errorf("Cannot create Vault Client: %v", err)
+		}
+
+		// By default Vault token is set from VAULT_TOKEN env var by NewClient()
+		// But if VAULT_TOKEN isn't set, token can be retrieved from ~/.vault-token file
+		if cli.Token() == "" {
+			homeDir := os.Getenv("HOME")
+			if homeDir != "" {
+				if buff, err := ioutil.ReadFile(homeDir + "/.vault-token"); err == nil {
+					cli.SetToken(string(buff))
+				}
+			}
 		}
 		p.client = cli
 	}


### PR DESCRIPTION
After successful `vault login` command token is stored into so-called token-helper file located at `~/.vault-token` [link](https://github.com/hashicorp/vault/blob/50f3870baedb9ef1c8ccdda1792b385aa52939fe/website/source/docs/commands/index.html.md#token-helper).

This PR adds ability to use this file for authenticating requests to vault.
Order of precedence: 1) if VAULT_TOKEN is set, use it, 2) Otherwise: try to use `~/.vault-token` file (if it doesn't exist etc errors won't be generated) 

So, workflow may be simplified a bit to:
```bash
vault login -method=....
# ~/.vault-token created
vals eval -f myfile.yaml
```
