### PR TITLE
fix: Remove old awssec package from imports

### DIFF
--- a/pkg/stringmapprovider/stringmapprovider.go
+++ b/pkg/stringmapprovider/stringmapprovider.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"github.com/variantdev/vals/pkg/api"
 	"github.com/variantdev/vals/pkg/providers/awssec"
-	"github.com/variantdev/vals/pkg/providers/awssecrets"
 	"github.com/variantdev/vals/pkg/providers/sops"
 	"github.com/variantdev/vals/pkg/providers/ssm"
 	"github.com/variantdev/vals/pkg/providers/vault"

--- a/pkg/stringprovider/stringprovider.go
+++ b/pkg/stringprovider/stringprovider.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"github.com/variantdev/vals/pkg/api"
 	"github.com/variantdev/vals/pkg/providers/awssec"
-	"github.com/variantdev/vals/pkg/providers/awssecrets"
 	"github.com/variantdev/vals/pkg/providers/sops"
 	"github.com/variantdev/vals/pkg/providers/ssm"
 	"github.com/variantdev/vals/pkg/providers/vault"


### PR DESCRIPTION
otherwise we'll get:
```
$ make
go build -o bin/vals ./cmd/vals
go: finding github.com/variantdev/vals/pkg/providers/awssecrets latest
go: finding github.com/variantdev/vals/pkg latest
go: finding github.com/variantdev/vals/pkg/providers latest
build github.com/variantdev/vals/cmd/vals: cannot load github.com/variantdev/vals/pkg/providers/awssecrets: no matching versions for query "latest"
make: *** [build] Error 1
```