### PR TITLE
introduce stopChar

### DIFF
--- a/pkg/expansion/expand_match.go
+++ b/pkg/expansion/expand_match.go
@@ -12,7 +12,7 @@ type ExpandRegexMatch struct {
 	Only   []string
 }
 
-var DefaultRefRegexp = regexp.MustCompile(`((secret)?ref)\+([^\+:]*://.+)`)
+var DefaultRefRegexp = regexp.MustCompile(`((secret)?ref)\+([^\+:]*://.+?)(?:(\n|#endref))`)
 
 func (e *ExpandRegexMatch) InString(s string) (string, error) {
 	var sb strings.Builder

--- a/vals.go
+++ b/vals.go
@@ -189,6 +189,17 @@ func (r *Runtime) Eval(template map[string]interface{}) (map[string]interface{},
 			path = strings.TrimPrefix(path, "#")
 			path = strings.TrimPrefix(path, "/")
 
+			stopCharacter, ok := uri.Query()["stopChar"]
+			var fragAfter = ""
+			if ok {
+				var stopCharacterIndex = strings.Index(frag, stopCharacter[0])
+				if (stopCharacterIndex < 0) {
+					return "", fmt.Errorf("stop character %s not found in %s", stopCharacter[0], frag)
+				}
+				fragAfter=frag[strings.Index(frag, stopCharacter[0]):]
+				frag=frag[:strings.Index(frag, stopCharacter[0])]
+			}
+
 			if uri.Host != "" {
 				path = strings.Join([]string{uri.Host, path}, "/")
 			}
@@ -209,7 +220,7 @@ func (r *Runtime) Eval(template map[string]interface{}) (map[string]interface{},
 					r.strCache.Add(cacheKey, str)
 				}
 
-				return str, nil
+				return str + fragAfter, nil
 			} else {
 				mapRequestURI := key[:strings.LastIndex(key, uri.Fragment)-1]
 				var obj map[string]interface{}
@@ -235,7 +246,7 @@ func (r *Runtime) Eval(template map[string]interface{}) (map[string]interface{},
 							return "", fmt.Errorf("unexpected type of value for key at %d=%s in %v: expected map[string]interface{}, got %v(%T)", i, k, keys, t, t)
 						}
 						r.docCache.Add(key, t)
-						return t, nil
+						return t + fragAfter, nil
 					case map[string]interface{}:
 						newobj = t
 					case map[interface{}]interface{}:

--- a/vals.go
+++ b/vals.go
@@ -189,17 +189,6 @@ func (r *Runtime) Eval(template map[string]interface{}) (map[string]interface{},
 			path = strings.TrimPrefix(path, "#")
 			path = strings.TrimPrefix(path, "/")
 
-			stopCharacter, ok := uri.Query()["stopChar"]
-			var fragAfter = ""
-			if ok {
-				var stopCharacterIndex = strings.Index(frag, stopCharacter[0])
-				if (stopCharacterIndex < 0) {
-					return "", fmt.Errorf("stop character %s not found in %s", stopCharacter[0], frag)
-				}
-				fragAfter=frag[strings.Index(frag, stopCharacter[0]):]
-				frag=frag[:strings.Index(frag, stopCharacter[0])]
-			}
-
 			if uri.Host != "" {
 				path = strings.Join([]string{uri.Host, path}, "/")
 			}
@@ -220,7 +209,7 @@ func (r *Runtime) Eval(template map[string]interface{}) (map[string]interface{},
 					r.strCache.Add(cacheKey, str)
 				}
 
-				return str + fragAfter, nil
+				return str, nil
 			} else {
 				mapRequestURI := key[:strings.LastIndex(key, uri.Fragment)-1]
 				var obj map[string]interface{}
@@ -246,7 +235,7 @@ func (r *Runtime) Eval(template map[string]interface{}) (map[string]interface{},
 							return "", fmt.Errorf("unexpected type of value for key at %d=%s in %v: expected map[string]interface{}, got %v(%T)", i, k, keys, t, t)
 						}
 						r.docCache.Add(key, t)
-						return t + fragAfter, nil
+						return t, nil
 					case map[string]interface{}:
 						newobj = t
 					case map[interface{}]interface{}:


### PR DESCRIPTION
While configuring Jenkins via helm I faced an issue:

I was trying to inject the secret into such a template

```yaml
master:
  securityRealm: |-
          <managerPasswordSecret>ref+vault://secret/data/test1#/bla</managerPasswordSecret>
```

And outcome was 

```yaml
master:
  securityRealm: |-
          <managerPasswordSecret>secret
```

e.g. everything after secret was ignored

I could find a workaround:

```yaml
master:
  securityRealm: |-
          <managerPasswordSecret>ref+vault://secret/data/test1#/bla#endref</managerPasswordSecret>
```

So here is a PR. It's a nasty solution, e.g. multiple occurrences within the same line will not work, but so far that's enough for me.