### PR TITLE
introduce endRef

### DIFF
--- a/pkg/expansion/expand_match.go
+++ b/pkg/expansion/expand_match.go
@@ -12,7 +12,7 @@ type ExpandRegexMatch struct {
 	Only   []string
 }
 
-var DefaultRefRegexp = regexp.MustCompile(`((secret)?ref)\+([^\+:]*://.+)`)
+var DefaultRefRegexp = regexp.MustCompile(`((secret)?ref)\+([^\+:]*://.+?)(?:$|#endref)`)
 
 func (e *ExpandRegexMatch) InString(s string) (string, error) {
 	var sb strings.Builder


### PR DESCRIPTION
While configuring Jenkins via helm I faced an issue:

I was trying to inject the secret into such a template

```yaml
master:
  securityRealm: |-
          <managerPasswordSecret>ref+vault://secret/data/test1#/bla</managerPasswordSecret>
```

And outcome was 

```yaml
master:
  securityRealm: |-
          <managerPasswordSecret>secret
```

e.g. everything after secret was ignored

I could find a workaround:

```yaml
master:
  securityRealm: |-
          <managerPasswordSecret>ref+vault://secret/data/test1#/bla#endref</managerPasswordSecret>
```