### PR TITLE
fix: prepend homedir only once when reading vault token

### DIFF
--- a/pkg/providers/vault/vault.go
+++ b/pkg/providers/vault/vault.go
@@ -215,15 +215,11 @@ func (p *provider) ensureClient() (*vault.Client, error) {
 }
 
 func (p *provider) readTokenFile(path string) (string, error) {
-	homeDir := os.Getenv("HOME")
-	if homeDir != "" {
-		buff, err := ioutil.ReadFile(filepath.Join(homeDir, path))
-		if err != nil {
-			return "", err
-		}
-		return string(buff), nil
+	buff, err := ioutil.ReadFile(path)
+	if err != nil {
+		return "", err
 	}
-	return "", nil
+	return string(buff), nil
 }
 
 func (p *provider) debugf(msg string, args ...interface{}) {


### PR DESCRIPTION
Fixes #29 

The home directory is already prepended to the file path [here](https://github.com/variantdev/vals/blob/master/pkg/providers/vault/vault.go#L183-L193)
