### PR TITLE
vault provider: adapt to both v1 and v2 secret paths

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -128,6 +128,7 @@ github.com/aws/aws-sdk-go v1.22.2 h1:uYP58k2Cd9y1qBy8CxTe5ADmdi4kANm8Ul8ch3kkIcQ
 github.com/aws/aws-sdk-go v1.22.2/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.29.34 h1:yrzwfDaZFe9oT4AmQeNNunSQA7c0m2chz0B43+bJ1ok=
 github.com/aws/aws-sdk-go v1.29.34/go.mod h1:1KvfttTE3SPKMpo8g2c6jL3ZKfXtFvKscTgahTma5Xg=
+github.com/aws/aws-sdk-go v1.30.7 h1:IaXfqtioP6p9SFAnNfsqdNczbR5UNbYqvcZUSsCAdTY=
 github.com/aws/aws-sdk-go v1.30.7/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/baiyubin/aliyun-sts-go-sdk v0.0.0-20180326062324-cfa1a18b161f/go.mod h1:AuiFmCCPBSrqvVMvuqFuk0qogytodnVFVSN5CeJB8Gc=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLMYoU8P317H5OQ+Via4RmuPwCS0=
@@ -472,6 +473,7 @@ github.com/jehiah/go-strftime v0.0.0-20171201141054-1d33003b3869 h1:IPJ3dvxmJ4uc
 github.com/jehiah/go-strftime v0.0.0-20171201141054-1d33003b3869/go.mod h1:cJ6Cj7dQo+O6GJNiMx+Pa94qKj+TG8ONdKHgMNIyyag=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
+github.com/jmespath/go-jmespath v0.3.0 h1:OS12ieG61fsCg5+qLJ+SsW9NicxNkg3b25OyT2yCeUc=
 github.com/jmespath/go-jmespath v0.3.0/go.mod h1:9QtRXoHjLGCJ5IBSaohpXITPlowMeeYCZ7fLUTSywik=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/joyent/triton-go v0.0.0-20190112182421-51ffac552869/go.mod h1:U+RSyWxWd04xTqnuOQxnai7XGS2PrPY2cfGoDKtMHjA=

--- a/pkg/providers/vault/kv_helper.go
+++ b/pkg/providers/vault/kv_helper.go
@@ -1,0 +1,85 @@
+package vault
+
+import (
+	"errors"
+	"path"
+	"strings"
+
+	"github.com/hashicorp/vault/api"
+)
+
+// Taken from https://github.com/hashicorp/vault/blob/master/command/kv_helpers.go
+func kvPreflightVersionRequest(client *api.Client, path string) (string, int, error) {
+	// We don't want to use a wrapping call here so save any custom value and
+	// restore after
+	currentWrappingLookupFunc := client.CurrentWrappingLookupFunc()
+	client.SetWrappingLookupFunc(nil)
+	defer client.SetWrappingLookupFunc(currentWrappingLookupFunc)
+	currentOutputCurlString := client.OutputCurlString()
+	client.SetOutputCurlString(false)
+	defer client.SetOutputCurlString(currentOutputCurlString)
+
+	r := client.NewRequest("GET", "/v1/sys/internal/ui/mounts/"+path)
+	resp, err := client.RawRequest(r)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+	if err != nil {
+		// If we get a 404 we are using an older version of vault, default to
+		// version 1
+		if resp != nil && resp.StatusCode == 404 {
+			return "", 1, nil
+		}
+
+		return "", 0, err
+	}
+
+	secret, err := api.ParseSecret(resp.Body)
+	if err != nil {
+		return "", 0, err
+	}
+	if secret == nil {
+		return "", 0, errors.New("nil response from pre-flight request")
+	}
+	var mountPath string
+	if mountPathRaw, ok := secret.Data["path"]; ok {
+		mountPath = mountPathRaw.(string)
+	}
+	options := secret.Data["options"]
+	if options == nil {
+		return mountPath, 1, nil
+	}
+	versionRaw := options.(map[string]interface{})["version"]
+	if versionRaw == nil {
+		return mountPath, 1, nil
+	}
+	version := versionRaw.(string)
+	switch version {
+	case "", "1":
+		return mountPath, 1, nil
+	case "2":
+		return mountPath, 2, nil
+	}
+
+	return mountPath, 1, nil
+}
+
+func isKVv2(path string, client *api.Client) (string, bool, error) {
+	mountPath, version, err := kvPreflightVersionRequest(client, path)
+	if err != nil {
+		return "", false, err
+	}
+
+	return mountPath, version == 2, nil
+}
+
+func addPrefixToVKVPath(p, mountPath, apiPrefix string) string {
+	switch {
+	case p == mountPath, p == strings.TrimSuffix(mountPath, "/"):
+		return path.Join(mountPath, apiPrefix)
+	default:
+		p = strings.TrimPrefix(p, mountPath)
+		return path.Join(mountPath, apiPrefix, p)
+	}
+}
+

--- a/pkg/providers/vault/vault.go
+++ b/pkg/providers/vault/vault.go
@@ -114,6 +114,15 @@ func (p *provider) GetStringMap(key string) (map[string]interface{}, error) {
 		return nil, fmt.Errorf("Cannot create Vault Client: %v", err)
 	}
 
+	mountPath, v2, err := isKVv2(key, cli)
+	if err != nil {
+		return nil, err
+	}
+
+	if v2 {
+		key = addPrefixToVKVPath(key, mountPath, "data")
+	}
+
 	res := map[string]interface{}{}
 
 	data := map[string][]string{}
@@ -135,9 +144,11 @@ func (p *provider) GetStringMap(key string) (map[string]interface{}, error) {
 	secrets := secret.Data
 
 	// Vault KV Version 2
-	if _, ok := secret.Data["data"]; ok {
-		if m, ok := secret.Data["data"].(map[string]interface{}); ok {
-			secrets = m
+	if v2 {
+		if _, ok := secret.Data["data"]; ok {
+			if m, ok := secret.Data["data"].(map[string]interface{}); ok {
+				secrets = m
+			}
 		}
 	}
 


### PR DESCRIPTION
This makes the vals reference opaque to the underlying vault secrets
engine version