### PR TITLE
Use double slash for relative and tripple slash for absolute path

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,8 @@ Examples:
 
 ### Terraform (tfstate)
 
-- `ref+tfstate://path/to/some.tfstate/RESOURCE_NAME`
+- `ref+tfstate://relative/path/to/some.tfstate/RESOURCE_NAME`
+- `ref+tfstate:///absolute/path/to/some.tfstate/RESOURCE_NAME`
 
 Examples:
 
@@ -362,11 +363,13 @@ Examples:
 
 File provider reads a local text file, or the value for the specific path in a YAML/JSON file.
 
-- `ref+file://path/to/file[#/path/to/the/value]`
+- `ref+file://relative/path/to/file[#/path/to/the/value]`
+- `ref+file:///absolute/path/to/file[#/path/to/the/value]`
 
 Examples:
 
 - `ref+file://foo/bar` loads the file at `foo/bar`
+- `ref+file:///home/foo/bar` loads the file at `/home/foo/bar`
 - `ref+file://some.yaml#/foo/bar` loads the YAML file at `some.yaml` and reads the value for the path `$.foo.bar`.
   Let's say `some.yaml` contains `{"foo":{"bar":"BAR"}}`, `key1: ref+file://some.yaml#/foo/bar` results in `key1: BAR`.
 

--- a/vals.go
+++ b/vals.go
@@ -4,12 +4,13 @@ import (
 	"crypto/md5"
 	"errors"
 	"fmt"
-	"github.com/variantdev/vals/pkg/config"
-	"github.com/variantdev/vals/pkg/providers/s3"
 	"net/url"
 	"os"
 	"os/exec"
 	"strings"
+
+	"github.com/variantdev/vals/pkg/config"
+	"github.com/variantdev/vals/pkg/providers/s3"
 
 	lru "github.com/hashicorp/golang-lru"
 	"github.com/variantdev/vals/pkg/api"
@@ -209,9 +210,10 @@ func (r *Runtime) Eval(template map[string]interface{}) (map[string]interface{},
 			frag = strings.TrimPrefix(frag, "/")
 
 			var components []string
+			var host string
 
 			{
-				host := uri.Host
+				host = uri.Host
 
 				if host != "" {
 					components = append(components, host)
@@ -221,7 +223,9 @@ func (r *Runtime) Eval(template map[string]interface{}) (map[string]interface{},
 			{
 				path2 := uri.Path
 				path2 = strings.TrimPrefix(path2, "#")
-				path2 = strings.TrimPrefix(path2, "/")
+				if host != "" {
+					path2 = strings.TrimPrefix(path2, "/")
+				}
 
 				if path2 != "" {
 					components = append(components, path2)


### PR DESCRIPTION
Hi. I tried to use tfstate schema and noticed I need to use 4 slashes to use the absolute path:

```
ref+tfstate:////home/piotr.roszatycki/Terraform/test/.terraform/terraform.tfstate/foo
```

It is really ugly and odd. Usually tripple slashes is used for absolute paths (like `file:///home/foo`) and no slashes for relative paths. I get that it would be difficult to not use slashes at all then we could follow the pattern that double slash is for relative path like:

```
ref+tfstate://.terraform/terraform.tfstate/foo
```

and tripple for absolute:

```
ref+tfstate:///home/piotr.roszatycki/Terraform/test/.terraform/terraform.tfstate/foo
```
