### PR TITLE
New schemas tfstates3 and tfstategs

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,48 @@ Remote backends like S3 is also supported. When a remote backend is used in your
 
 Just specify the path to that file, so that `vals` is able to transparently make the remote state contents available for you.
 
+### Terraform in GCS bucket (tfstategs)
+
+- `ref+tfstategs://bucket/path/to/some.tfstate/RESOURCE_NAME`
+
+Examples:
+
+- `ref+tfstate://bucket/path/to/some.tfstate/google_compute_disk.instance.id`
+
+It allows to use Terraform state stored in GCS bucket with the direct URL to it. You can try to read the state with command: 
+
+```
+$ tfstate-lookup -s gs://bucket-with-terraform-state/terraform.tfstate google_compute_disk.instance.source_image_id
+5449927740744213880
+```
+
+which is equivalent to the following input for `vals`:
+
+```
+$ echo 'foo: ref+tfstategs://bucket-with-terraform-state/terraform.tfstate/google_compute_disk.instance.source_image_id' | vals eval -f -
+```
+
+### Terraform in S3 bucket (tfstates3)
+
+- `ref+tfstates3://bucket/path/to/some.tfstate/RESOURCE_NAME`
+
+Examples:
+
+- `ref+tfstate://bucket/path/to/some.tfstate/aws_vpc.main.id`
+
+It allows to use Terraform state stored in AWS S3 bucket with the direct URL to it. You can try to read the state with command: 
+
+```
+$ tfstate-lookup -s s3://bucket-with-terraform-state/terraform.tfstate module.vpc.aws_vpc.this[0].arn
+arn:aws:ec2:us-east-2:ACCOUNT_ID:vpc/vpc-0cb48a12e4df7ad4c
+```
+
+which is equivalent to the following input for `vals`:
+
+```
+$ echo 'foo: ref+tfstates3://bucket-with-terraform-state/terraform.tfstate/module.vpc.aws_vpc.this[0].arn' | vals eval -f -
+```
+
 ### SOPS
 
 - The whole content of a SOPS-encrypted file: `ref+sops://base64_data_or_path_to_file?key_type=[filepath|base64]&format=[binary|dotenv|yaml]`

--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ $ echo 'foo: ref+tfstategs://bucket-with-terraform-state/terraform.tfstate/googl
 
 Examples:
 
-- `ref+tfstate://bucket/path/to/some.tfstate/aws_vpc.main.id`
+- `ref+tfstates3://bucket/path/to/some.tfstate/aws_vpc.main.id`
 
 It allows to use Terraform state stored in AWS S3 bucket with the direct URL to it. You can try to read the state with command: 
 

--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ Just specify the path to that file, so that `vals` is able to transparently make
 
 Examples:
 
-- `ref+tfstate://bucket/path/to/some.tfstate/google_compute_disk.instance.id`
+- `ref+tfstategs://bucket/path/to/some.tfstate/google_compute_disk.instance.id`
 
 It allows to use Terraform state stored in GCS bucket with the direct URL to it. You can try to read the state with command: 
 

--- a/pkg/stringprovider/stringprovider.go
+++ b/pkg/stringprovider/stringprovider.go
@@ -31,7 +31,11 @@ func New(provider api.StaticConfig) (api.LazyLoadedStringProvider, error) {
 	case "gcpsecrets":
 		return gcpsecrets.New(provider), nil
 	case "tfstate":
-		return tfstate.New(provider), nil
+		return tfstate.New(provider, ""), nil
+	case "tfstategs":
+		return tfstate.New(provider, "gs"), nil
+	case "tfstates3":
+		return tfstate.New(provider, "s3"), nil
 	case "azurekeyvault":
 		return azurekeyvault.New(provider), nil
 	}

--- a/vals.go
+++ b/vals.go
@@ -4,12 +4,13 @@ import (
 	"crypto/md5"
 	"errors"
 	"fmt"
-	"github.com/variantdev/vals/pkg/config"
-	"github.com/variantdev/vals/pkg/providers/s3"
 	"net/url"
 	"os"
 	"os/exec"
 	"strings"
+
+	"github.com/variantdev/vals/pkg/config"
+	"github.com/variantdev/vals/pkg/providers/s3"
 
 	lru "github.com/hashicorp/golang-lru"
 	"github.com/variantdev/vals/pkg/api"
@@ -60,6 +61,8 @@ const (
 	ProviderFile             = "file"
 	ProviderGCPSecretManager = "gcpsecrets"
 	ProviderTFState          = "tfstate"
+	ProviderTFStateGS        = "tfstategs"
+	ProviderTFStateS3        = "tfstates3"
 	ProviderAzureKeyVault    = "azurekeyvault"
 )
 
@@ -157,7 +160,13 @@ func (r *Runtime) Eval(template map[string]interface{}) (map[string]interface{},
 			p := gcpsecrets.New(conf)
 			return p, nil
 		case ProviderTFState:
-			p := tfstate.New(conf)
+			p := tfstate.New(conf, "")
+			return p, nil
+		case ProviderTFStateGS:
+			p := tfstate.New(conf, "gs")
+			return p, nil
+		case ProviderTFStateS3:
+			p := tfstate.New(conf, "s3")
 			return p, nil
 		case ProviderAzureKeyVault:
 			p := azurekeyvault.New(conf)


### PR DESCRIPTION
This patch adds new schemes that can allow to use direct path to Terraform state in the bucket: one for GCS another for S3.

The patch requires first #47 to be applied as far as it support GCS buckets implemented by tfstate-lookup v0.2.0

It should solve #45 