### PR TITLE
Add Vault namespace native support

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,11 +180,12 @@ Please see [pkg/providers](https://github.com/variantdev/vals/tree/master/pkg/pr
 
 ### Vault
 
-- `ref+vault://PATH/TO/KVBACKEND[?address=VAULT_ADDR:PORT&token_file=PATH/TO/FILE&token_env=VAULT_TOKEN]#/fieldkey`
+- `ref+vault://PATH/TO/KVBACKEND[?address=VAULT_ADDR:PORT&token_file=PATH/TO/FILE&token_env=VAULT_TOKEN&namespace=VAULT_NAMESPACE]#/fieldkey`
 - `ref+vault://PATH/TO/KVBACKEND[?address=VAULT_ADDR:PORT&auth_method=approle&role_id=ce5e571a-f7d4-4c73-93dd-fd6922119839&secret_id=5c9194b9-585e-4539-a865-f45604bd6f56]#/fieldkey`
 - `ref+vault://PATH/TO/KVBACKEND[?address=VAULT_ADDR:PORT&auth_method=kubernetes&role_id=K8S-ROLE`
 
 * `address` defaults to the value of the `VAULT_ADDR` envvar.
+* `namespace` defaults to the value of the `VAULT_NAMESPACE` envvar.
 * `auth_method` default to `token` and can also be set to the value of the `VAULT_AUTH_METHOD` envar.
 * `role_id` defaults to the value of the `VAULT_ROLE_ID` envvar.
 * `secret_id` defaults to the value of the `VAULT_SECRET_ID` envvar.
@@ -201,7 +202,7 @@ The `auth_method` or `VAULT_AUTH_METHOD` envar configures how `vals` authenticat
 Examples:
 
 - `ref+vault://mykv/foo#/bar?address=https://vault1.example.com:8200` reads the value for the field `bar` in the kv `foo` on Vault listening on `https://vault1.example.com` with the Vault token read from **the envvar `VAULT_TOKEN`, or the file `~/.vault_token` when the envvar is not set**
-- `ref+vault://mykv/foo#/bar?token_env=VAULT_TOKEN_VAULT1&address=https://vault1.example.com:8200` reads the value for the field `bar` in the kv `foo` on Vault listening on `https://vault1.example.com` with the Vault token read from **the envvar `VAULT_TOKEN_VAULT1`**
+- `ref+vault://mykv/foo#/bar?token_env=VAULT_TOKEN_VAULT1&namespace=ns1&address=https://vault1.example.com:8200` reads the value for the field `bar` from namespace `ns1` in the kv `foo` on Vault listening on `https://vault1.example.com` with the Vault token read from **the envvar `VAULT_TOKEN_VAULT1`**
 - `ref+vault://mykv/foo#/bar?token_file=~/.vault_token_vault1&address=https://vault1.example.com:8200` reads the value for the field `bar` in the kv `foo` on Vault listening on `https://vault1.example.com` with the Vault token read from **the file `~/.vault_token_vault1`**
 - `ref+vault://mykv/foo#/bar?role_id=my-kube-role` using the Kubernetes role to log in to Vault
 

--- a/pkg/providers/vault/vault.go
+++ b/pkg/providers/vault/vault.go
@@ -26,6 +26,7 @@ type provider struct {
 	client *vault.Client
 
 	Address    string
+	Namespace  string
 	Proto      string
 	Host       string
 	TokenEnv   string
@@ -56,6 +57,7 @@ func New(cfg api.StaticConfig) *provider {
 			p.Address = os.Getenv("VAULT_ADDR")
 		}
 	}
+	p.Namespace = cfg.String("namespace")
 	p.TokenEnv = cfg.String("token_env")
 	p.TokenFile = cfg.String("token_file")
 	p.AuthMethod = cfg.String("auth_method")
@@ -175,6 +177,9 @@ func (p *provider) ensureClient() (*vault.Client, error) {
 		if err != nil {
 			p.debugf("Vault connections failed")
 			return nil, fmt.Errorf("Cannot create Vault Client: %v", err)
+		}
+		if p.Namespace != "" {
+			cli.setNamespace(p.Namespace)
 		}
 
 		if p.AuthMethod == "token" {

--- a/pkg/providers/vault/vault.go
+++ b/pkg/providers/vault/vault.go
@@ -179,7 +179,7 @@ func (p *provider) ensureClient() (*vault.Client, error) {
 			return nil, fmt.Errorf("Cannot create Vault Client: %v", err)
 		}
 		if p.Namespace != "" {
-			cli.setNamespace(p.Namespace)
+			cli.SetNamespace(p.Namespace)
 		}
 
 		if p.AuthMethod == "token" {


### PR DESCRIPTION
Vault namespaces is an enterprise-only feature that we will start making use of very soon. It is already supported via the `VAULT_NAMESPACE` environment variable, but this adds native support to vals for it so that it can be set in the ref.

This is my first time in go, so please be kind :)