### PR TITLE
fix(sops): decode base64 data before passing to SOPS

### DIFF
--- a/pkg/providers/sops/sops.go
+++ b/pkg/providers/sops/sops.go
@@ -3,6 +3,7 @@ package sops
 import (
 	"fmt"
 	"os"
+	"encoding/base64"
 
 	"github.com/variantdev/vals/pkg/api"
 	"gopkg.in/yaml.v3"
@@ -62,7 +63,11 @@ func (p *provider) format(defaultFormat string) string {
 
 func (p *provider) decrypt(keyOrData, format string) ([]byte, error) {
 	if p.KeyType == "base64" {
-		return decrypt.Data([]byte(keyOrData), format)
+		blob, err := base64.StdEncoding.DecodeString(keyOrData)
+		if err != nil {
+			return nil, err
+		}
+		return decrypt.Data(blob, format)
 	} else if p.KeyType == "filepath" {
 		return decrypt.File(keyOrData, format)
 	} else {


### PR DESCRIPTION
Should fix #84 

I'm not a Go programmer, so it's possible I've mucked this up, but, it's a pretty simple fix and it does seem to work.