### PR TITLE
feat: add awskms provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,10 +282,46 @@ Examples:
 
 #### AWS KMS
 
-- `ref+awskms://BASE64CIPHERTEXT[?region=REGION&profile=AWS_PROFILE]`
+- `ref+awskms://BASE64CIPHERTEXT[?region=REGION&profile=AWS_PROFILE&alg=ENCRYPTION_ALGORITHM&key=KEY_ID&context=URL_ENCODED_JSON]`
+- `ref+awskms://BASE64CIPHERTEXT[?region=REGION&profile=AWS_PROFILE&alg=ENCRYPTION_ALGORITHM&key=KEY_ID&context=URL_ENCODED_JSON]#/yaml_or_json_key/in/secret`
+
+Decrypts the URL-safe base64-encoded ciphertext using AWS KMS. Note that URL-safe base64 encoding is
+the same as "traditional" base64 encoding, except it uses `_` and `-` in place of `/` and `+`, respectively.
+For example, to get a URL-safe base64-encoded ciphertext using the AWS CLI, you might run
+```
+aws kms encrypt \
+  --key-id alias/example \
+  --plaintext $(echo -n "hello, world" | base64 -w0) \
+  --query CiphertextBlob \
+  --output text |
+  tr '/+' '_-'
+```
+
+Valid values for `alg` include:
+* `SYMMETRIC_DEFAULT` (the default)
+* `RSAES_OAEP_SHA_1`
+* `RSAES_OAEP_SHA_256`
+
+Valid value formats for `key` include:
+* A key id `1234abcd-12ab-34cd-56ef-1234567890ab`
+* A URL-encoded key id ARN: `arn%3Aaws%3Akms%3Aus-east-2%3A111122223333%3Akey%2F1234abcd-12ab-34cd-56ef-1234567890ab`
+* A URL-encoded key alias: `alias%2FExampleAlias`
+* A URL-encoded key alias ARN: `arn%3Aaws%3Akms%3Aus-east-2%3A111122223333%3Aalias%2FExampleAlias`
+For ciphertext encrypted with a symmetric key, the `key` field may be omitted. For ciphertext
+encrypted with a key in your own account, a plain key id or alias can be used. If the encryption
+key is from another AWS account, you must use the key or alias ARN.
+
+Use the `context` parameter to optionally specify the encryption context used when encrypting the
+ciphertext. Format it by URL-encoding the JSON representation of the encryption context. For example,
+if the encryption context is `{"foo":"bar","hello":"world"}`, then you would represent that as
+`context=%7B%22foo%22%3A%22bar%22%2C%22hello%22%2C%22world%22%7D`.
 
 Examples:
-- `foo: ref+awskms://AQICAHhyi8hQoGLOE46PVJyinH...WwHKT0i3H0znHRHwfyC7AGZ8ek=`
+- `ref+awskms://AQICAHhy_i8hQoGLOE46PVJyinH...WwHKT0i3H0znHRHwfyC7AGZ8ek=`
+- `ref+awskms://AQICAHhy...nHRHwfyC7AGZ8ek=#/foo/bar`
+- `ref+awskms://AQICAHhy...WwHKT0i3AGZ8ek=?context=%7B%22foo%22%3A%22bar%22%2C%22hello%22%2C%22world%22%7D`
+- `ref+awskms://AQICAVJyinH...WwHKT0iC7AGZ8ek=?alg=RSAES_OAEP_SHA1&key=alias%2FExampleAlias`
+- `ref+awskms://AQICA...fyC7AGZ8ek=?alg=RSAES_OAEP_SHA256&key=arn%3Aaws%3Akms%3Aus-east-2%3A111122223333%3Akey%2F1234abcd-12ab-34cd-56ef-1234567890ab&context=%7B%22foo%22%3A%22bar%22%2C%22hello%22%2C%22world%22%7D`
 
 #### Google GCS
 - `ref+gcs://BUCKET/KEY/OF/OBJECT[?generation=ID]`

--- a/README.md
+++ b/README.md
@@ -207,10 +207,12 @@ Examples:
 
 ### AWS
 
-There are two providers for AWS:
+There are three providers for AWS:
 
 - SSM Parameter Store
 - Secrets Manager
+- S3
+- KMS
 
 Both provider have support for specifying AWS region and profile via envvars or options:
 
@@ -277,6 +279,13 @@ Examples:
 - `ref+s3://mybucket/myyamlobj#/foo/bar`
 - `ref+s3://mybucket/mykey?region=us-west-2`
 - `ref+s3://mybucket/mykey?profile=prod`
+
+#### AWS KMS
+
+- `ref+awskms://BASE64CIPHERTEXT[?region=REGION&profile=AWS_PROFILE]`
+
+Examples:
+- `foo: ref+awskms://AQICAHhyi8hQoGLOE46PVJyinH...WwHKT0i3H0znHRHwfyC7AGZ8ek=`
 
 #### Google GCS
 - `ref+gcs://BUCKET/KEY/OF/OBJECT[?generation=ID]`

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ Examples:
 
 ### AWS
 
-There are three providers for AWS:
+There are four providers for AWS:
 
 - SSM Parameter Store
 - Secrets Manager

--- a/pkg/providers/awskms/awskms.go
+++ b/pkg/providers/awskms/awskms.go
@@ -1,0 +1,61 @@
+package awskms
+
+import (
+	"encoding/base64"
+
+	"github.com/variantdev/vals/pkg/api"
+	"github.com/aws/aws-sdk-go/service/kms"
+	"github.com/variantdev/vals/pkg/awsclicompat"
+)
+
+type provider struct {
+	// Keeping track of KMS services since we need a service per region
+	client *kms.KMS
+
+	// AWS KMS global configuration
+	Region, Profile string
+}
+
+func New(cfg api.StaticConfig) *provider {
+	p := &provider{}
+	p.Region = cfg.String("region")
+	p.Profile = cfg.String("profile")
+	return p
+}
+
+func (p *provider) GetString(key string) (string, error) {
+	cli := p.getClient()
+
+	blob, err := base64.StdEncoding.DecodeString(key)
+	if err != nil {
+		return "", err
+	}
+
+	in := &kms.DecryptInput{
+		CiphertextBlob: blob,
+	}
+
+	result, err := cli.Decrypt(in)
+	if err != nil {
+		return "", err
+	}
+
+	return string(result.Plaintext), nil
+}
+
+func (p *provider) GetStringMap(key string) (map[string]interface{}, error) {
+	// I do not understand what this is supposed to be doing, but, having it
+	// do nothing seems to work (while not implementing it at all does not).
+	return map[string]interface{}{}, nil
+}
+
+func (p *provider) getClient() *kms.KMS {
+	if p.client != nil {
+		return p.client
+	}
+
+	sess := awsclicompat.NewSession(p.Region, p.Profile)
+
+	p.client = kms.New(sess)
+	return p.client
+}

--- a/pkg/stringmapprovider/stringmapprovider.go
+++ b/pkg/stringmapprovider/stringmapprovider.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/variantdev/vals/pkg/api"
+	"github.com/variantdev/vals/pkg/providers/awskms"
 	"github.com/variantdev/vals/pkg/providers/awssecrets"
 	"github.com/variantdev/vals/pkg/providers/azurekeyvault"
 	"github.com/variantdev/vals/pkg/providers/gcpsecrets"
@@ -30,6 +31,8 @@ func New(provider api.StaticConfig) (api.LazyLoadedStringMapProvider, error) {
 		return gcpsecrets.New(provider), nil
 	case "azurekeyvault":
 		return azurekeyvault.New(provider), nil
+	case "awskms":
+		return awskms.New(provider), nil
 	}
 
 	return nil, fmt.Errorf("failed initializing string-map provider from config: %v", provider)

--- a/pkg/stringprovider/stringprovider.go
+++ b/pkg/stringprovider/stringprovider.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/variantdev/vals/pkg/api"
+	"github.com/variantdev/vals/pkg/providers/awskms"
 	"github.com/variantdev/vals/pkg/providers/awssecrets"
 	"github.com/variantdev/vals/pkg/providers/azurekeyvault"
 	"github.com/variantdev/vals/pkg/providers/gcpsecrets"
@@ -27,6 +28,8 @@ func New(provider api.StaticConfig) (api.LazyLoadedStringProvider, error) {
 		return ssm.New(provider), nil
 	case "vault":
 		return vault.New(provider), nil
+	case "awskms":
+		return awskms.New(provider), nil
 	case "awssecrets":
 		return awssecrets.New(provider), nil
 	case "sops":

--- a/vals.go
+++ b/vals.go
@@ -15,6 +15,7 @@ import (
 	lru "github.com/hashicorp/golang-lru"
 	"github.com/variantdev/vals/pkg/api"
 	"github.com/variantdev/vals/pkg/expansion"
+	"github.com/variantdev/vals/pkg/providers/awskms"
 	"github.com/variantdev/vals/pkg/providers/awssecrets"
 	"github.com/variantdev/vals/pkg/providers/azurekeyvault"
 	"github.com/variantdev/vals/pkg/providers/echo"
@@ -57,6 +58,7 @@ const (
 	ProviderS3               = "s3"
 	ProviderGCS              = "gcs"
 	ProviderSSM              = "awsssm"
+	ProviderKms              = "awskms"
 	ProviderSecretsManager   = "awssecrets"
 	ProviderSOPS             = "sops"
 	ProviderEcho             = "echo"
@@ -186,6 +188,9 @@ func (r *Runtime) Eval(template map[string]interface{}) (map[string]interface{},
 			return p, nil
 		case ProviderAzureKeyVault:
 			p := azurekeyvault.New(conf)
+			return p, nil
+		case ProviderKms:
+			p := awskms.New(conf)
 			return p, nil
 		}
 		return nil, fmt.Errorf("no provider registered for scheme %q", scheme)


### PR DESCRIPTION
An alternative implementation of the `awskms` provider, inspired by #41.

This implementation works the way you suggested it should in #41, with `ref+awskms://BASE64CIPHERTEXT` resolving to the cleartext encoded by said ciphertext. The indirection/`ref+vals://` support from #41 is not included.

Note that while I have tested this code and it does work, I am not a Go programmer, so I can't really vouch for its quality. In particular, I didn't understand the intended purpose of having the `GetStringMap` function in addition to the `GetString` function; even with an empty implementation, the `awskms` provider does seem to work, but, I assume it's missing some functionality given that I didn't really properly implement one of the necessary methods.