### PR TITLE
fix(sops): Use URL-safe Base64 encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,7 @@ Valid value formats for `key` include:
 * A URL-encoded key id ARN: `arn%3Aaws%3Akms%3Aus-east-2%3A111122223333%3Akey%2F1234abcd-12ab-34cd-56ef-1234567890ab`
 * A URL-encoded key alias: `alias%2FExampleAlias`
 * A URL-encoded key alias ARN: `arn%3Aaws%3Akms%3Aus-east-2%3A111122223333%3Aalias%2FExampleAlias`
+
 For ciphertext encrypted with a symmetric key, the `key` field may be omitted. For ciphertext
 encrypted with a key in your own account, a plain key id or alias can be used. If the encryption
 key is from another AWS account, you must use the key or alias ARN.

--- a/README.md
+++ b/README.md
@@ -490,6 +490,11 @@ $ echo 'foo: ref+tfstateremote://app.terraform.io/myorg/myworkspace/output.virtu
 - The whole content of a SOPS-encrypted file: `ref+sops://base64_data_or_path_to_file?key_type=[filepath|base64]&format=[binary|dotenv|yaml]`
 - The value for the specific path in an encrypted YAML/JSON document: `ref+sops://base64_data_or_path_to_file#/json_or_yaml_key/in/the_encrypted_doc`
 
+Note: When using an inline base64-encoded sops "file", be sure to use URL-safe Base64 encoding.
+URL-safe base64 encoding is the same as "traditional" base64 encoding, except it uses `_` and `-` in
+place of `/` and `+`, respectively. For example, you might use the following command:
+`sops -e <(echo "foo") | base64 -w0 | tr '/+' '_-'`
+
 Examples:
 
 - `ref+sops://path/to/file` reads `path/to/file` as `binary` input
@@ -544,8 +549,8 @@ Environment variables substitution.
 Examples:
 
 - `ref+envsubst://$VAR1` loads environment variables `$VAR1`
- 
- 
+
+
 #### Authentication
 
 Vals aquires Azure credentials though Azure CLI or from environment variables. The easiest way is to run `az login`. Vals can then aquire the current credentials from `az` without further set up.

--- a/pkg/providers/awskms/awskms.go
+++ b/pkg/providers/awskms/awskms.go
@@ -1,15 +1,14 @@
 package awskms
 
 import (
-	"fmt"
-	"strings"
-	"os"
 	"encoding/base64"
+	"fmt"
+	"os"
 
 	"gopkg.in/yaml.v3"
 
-	"github.com/variantdev/vals/pkg/api"
 	"github.com/aws/aws-sdk-go/service/kms"
+	"github.com/variantdev/vals/pkg/api"
 	"github.com/variantdev/vals/pkg/awsclicompat"
 )
 

--- a/pkg/providers/sops/sops.go
+++ b/pkg/providers/sops/sops.go
@@ -63,7 +63,7 @@ func (p *provider) format(defaultFormat string) string {
 
 func (p *provider) decrypt(keyOrData, format string) ([]byte, error) {
 	if p.KeyType == "base64" {
-		blob, err := base64.StdEncoding.DecodeString(keyOrData)
+		blob, err := base64.URLEncoding.DecodeString(keyOrData)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This switches SOPS to using URL-safe base64 encoding, same as the AWSKMS provider uses.