### PR TITLE
Fix unwanted back-quoting in usage string

### DIFF
--- a/cmd/vals/main.go
+++ b/cmd/vals/main.go
@@ -101,7 +101,7 @@ func main() {
 	case CmdEnv:
 		execEnv := flag.NewFlagSet(CmdEnv, flag.ExitOnError)
 		f := execEnv.String("f", "", "YAML/JSON file to be loaded to set envvars")
-		export := execEnv.Bool("export", false, "Prepend `export`s to each line")
+		export := execEnv.Bool("export", false, "Prepend 'export' to each line")
 		execEnv.Parse(os.Args[2:])
 
 		m := readOrFail(f)


### PR DESCRIPTION
I think the back-quoting was not intended.
Compare the original output:
```
Usage of env:
  -export export
        Prepend exports to each line
  -f string
        YAML/JSON file to be loaded to set envvars
```
... to the suggested output with this patch:
```
Usage of env:
  -export
        Prepend 'export' to each line
  -f string
        YAML/JSON file to be loaded to set envvars
```
