### PR TITLE
Add fallback option to gcpsecrets provider

### DIFF
--- a/pkg/providers/gcpsecrets/gcpsecrets.go
+++ b/pkg/providers/gcpsecrets/gcpsecrets.go
@@ -15,7 +15,7 @@ import (
 	"github.com/variantdev/vals/pkg/api"
 )
 
-// Format: ref+gcpsecrets://project/mykey[?version=VERSION][&fallback=valuewhenkeyisnotfound]#/yaml_or_json_key/in/secret
+// Format: ref+gcpsecrets://project/mykey[?version=VERSION][&fallback=value=valuewhenkeyisnotfound][&optional=true]#/yaml_or_json_key/in/secret
 type provider struct {
 	client   *sm.Client
 	ctx      context.Context
@@ -47,8 +47,8 @@ func New(cfg api.StaticConfig) *provider {
 		}
 	}
 
-	if cfg.Exists("fallback") {
-		fallback := cfg.String("fallback")
+	if cfg.Exists("fallback_value") {
+		fallback := cfg.String("fallback_value")
 		p.fallback = &fallback
 	}
 

--- a/pkg/providers/gcpsecrets/gcpsecrets_test.go
+++ b/pkg/providers/gcpsecrets/gcpsecrets_test.go
@@ -1,11 +1,14 @@
 package gcpsecrets
 
 import (
-	config2 "github.com/variantdev/vals/pkg/config"
 	"testing"
+
+	config2 "github.com/variantdev/vals/pkg/config"
 )
 
 func Test_New(t *testing.T) {
+	defaultVal := "default-value"
+
 	tests := []struct {
 		name    string
 		options map[string]interface{}
@@ -13,6 +16,8 @@ func Test_New(t *testing.T) {
 	}{
 		{"latest", map[string]interface{}{"version": "latest"}, provider{version: "latest", optional: false}},
 		{"optional", map[string]interface{}{"version": "latest", "optional": true}, provider{version: "latest", optional: true}},
+		{"latest", map[string]interface{}{"version": "latest"}, provider{version: "latest", fallback: nil}},
+		{"fallback", map[string]interface{}{"version": "latest", "fallback": defaultVal}, provider{version: "latest", fallback: &defaultVal}},
 	}
 
 	for _, tt := range tests {

--- a/pkg/providers/gcpsecrets/gcpsecrets_test.go
+++ b/pkg/providers/gcpsecrets/gcpsecrets_test.go
@@ -17,7 +17,7 @@ func Test_New(t *testing.T) {
 		{"latest", map[string]interface{}{"version": "latest"}, provider{version: "latest", optional: false}},
 		{"optional", map[string]interface{}{"version": "latest", "optional": true}, provider{version: "latest", optional: true}},
 		{"latest", map[string]interface{}{"version": "latest"}, provider{version: "latest", fallback: nil}},
-		{"fallback", map[string]interface{}{"version": "latest", "fallback": defaultVal}, provider{version: "latest", fallback: &defaultVal}},
+		{"fallback", map[string]interface{}{"version": "latest", "fallback_value": defaultVal}, provider{version: "latest", fallback: &defaultVal}},
 	}
 
 	for _, tt := range tests {

--- a/vals_gcpsecrets_test.go
+++ b/vals_gcpsecrets_test.go
@@ -1,10 +1,11 @@
 package vals
 
 import (
-	"github.com/variantdev/vals/pkg/config"
 	"os"
 	"reflect"
 	"testing"
+
+	"github.com/variantdev/vals/pkg/config"
 )
 
 // setup:
@@ -42,11 +43,11 @@ func TestValues_GCPSecretsManager(t *testing.T) {
 			map[string]string{},
 			map[string]interface{}{
 				"provider": map[string]interface{}{
-					"name":     "gcpsecrets",
-					"version":  "latest",
-					"type":     "string",
-					"path":     projectId,
-					"fallback": "default-value",
+					"name":           "gcpsecrets",
+					"version":        "latest",
+					"type":           "string",
+					"path":           projectId,
+					"fallback_value": "default-value",
 				},
 				"inline": map[string]interface{}{
 					"missingvar": "missingvar",
@@ -59,11 +60,11 @@ func TestValues_GCPSecretsManager(t *testing.T) {
 			map[string]string{},
 			map[string]interface{}{
 				"provider": map[string]interface{}{
-					"name":     "gcpsecrets",
-					"version":  "latest",
-					"type":     "string",
-					"path":     projectId,
-					"fallback": "",
+					"name":           "gcpsecrets",
+					"version":        "latest",
+					"type":           "string",
+					"path":           projectId,
+					"fallback_value": "",
 				},
 				"inline": map[string]interface{}{
 					"missingvar": "missingvar",

--- a/vals_gcpsecrets_test.go
+++ b/vals_gcpsecrets_test.go
@@ -38,6 +38,40 @@ func TestValues_GCPSecretsManager(t *testing.T) {
 			map[string]interface{}{"valstestvar": "foo: bar"},
 		},
 		{
+			"fallback string",
+			map[string]string{},
+			map[string]interface{}{
+				"provider": map[string]interface{}{
+					"name":     "gcpsecrets",
+					"version":  "latest",
+					"type":     "string",
+					"path":     projectId,
+					"fallback": "default-value",
+				},
+				"inline": map[string]interface{}{
+					"missingvar": "missingvar",
+				},
+			},
+			map[string]interface{}{"missingvar": "default-value"},
+		},
+		{
+			"empty fallback string",
+			map[string]string{},
+			map[string]interface{}{
+				"provider": map[string]interface{}{
+					"name":     "gcpsecrets",
+					"version":  "latest",
+					"type":     "string",
+					"path":     projectId,
+					"fallback": "",
+				},
+				"inline": map[string]interface{}{
+					"missingvar": "missingvar",
+				},
+			},
+			map[string]interface{}{"missingvar": ""},
+		},
+		{
 			"v1 string",
 			map[string]string{"valstestvar": "foo: bar"},
 			map[string]interface{}{


### PR DESCRIPTION
We're using this with Helm and dynamic secret keys (e.g. `app__{{ .Environment.Name }}__DB_PASSWORD`, and in some environments we want a fixed value, or we want the value to empty. The fixed value could be solved by adding a secret with that fixed value, but an empty value is not allowed in GCP.

By providing a fallback option an empty string can be set as fallback.

Alternatively an option to ignore missing keys and defaulting to an empty string could work too.