### PR TITLE
Add "optional" option to gcpsecrets provider

### DIFF
--- a/pkg/providers/gcpsecrets/gcpsecrets_test.go
+++ b/pkg/providers/gcpsecrets/gcpsecrets_test.go
@@ -11,7 +11,8 @@ func Test_New(t *testing.T) {
 		options map[string]interface{}
 		want    provider
 	}{
-		{"latest", map[string]interface{}{"version": "latest"}, provider{version: "latest"}},
+		{"latest", map[string]interface{}{"version": "latest"}, provider{version: "latest", optional: false}},
+		{"optional", map[string]interface{}{"version": "latest", "optional": true}, provider{version: "latest", optional: true}},
 	}
 
 	for _, tt := range tests {

--- a/vals_gcpsecrets_test.go
+++ b/vals_gcpsecrets_test.go
@@ -54,6 +54,23 @@ func TestValues_GCPSecretsManager(t *testing.T) {
 			map[string]interface{}{"valstestvar": "foo: bar"},
 		},
 		{
+			"optional string",
+			map[string]string{},
+			map[string]interface{}{
+				"provider": map[string]interface{}{
+					"name":     "gcpsecrets",
+					"version":  "1",
+					"type":     "string",
+					"path":     projectId,
+					"optional": true,
+				},
+				"inline": map[string]interface{}{
+					"missingvar": "",
+				},
+			},
+			map[string]interface{}{"missingvar": ""},
+		},
+		{
 			"v1 map",
 			map[string]string{"valstestvar": "foo: bar"},
 			map[string]interface{}{


### PR DESCRIPTION
Alternate approach for the problem described in https://github.com/variantdev/vals/pull/98

----

We're using this with Helm and dynamic secret keys (e.g. `app__{{ .Environment.Name }}__DB_PASSWORD`, and in some environments we want a fixed value, or we want the value to empty. The fixed value could be solved by adding a secret with that fixed value, but an empty value is not allowed in GCP.

By making a value optional we can safely ignore errors.