### PR TITLE
Fix vals version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 Version := $(shell git describe --tags --dirty)
 GitCommit := $(shell git rev-parse HEAD)
-LDFLAGS := "-X main.Version=$(Version) -X main.GitCommit=$(GitCommit)"
+LDFLAGS := "-X main.version=$(Version) -X main.commit=$(GitCommit)"
 
 build:
 	go build -ldflags $(LDFLAGS) -o bin/vals ./cmd/vals

--- a/cmd/vals/main.go
+++ b/cmd/vals/main.go
@@ -13,8 +13,8 @@ import (
 )
 
 var (
-	Version   string
-	GitCommit string
+	version string
+	commit  string
 )
 
 func flagUsage() {
@@ -162,12 +162,12 @@ func main() {
 			}
 		}
 	case CmdVersion:
-		if len(Version) == 0 {
+		if len(version) == 0 {
 			fmt.Println("Version: dev")
 		} else {
-			fmt.Println("Version:", Version)
+			fmt.Println("Version:", version)
 		}
-		fmt.Println("Git Commit:", GitCommit)
+		fmt.Println("Git Commit:", commit)
 	default:
 		flag.Usage()
 	}


### PR DESCRIPTION
Fix #96 

Use the ldflags from [goreleaser](https://goreleaser.com/customization/build/).

```
    # Custom ldflags templates.
    # Default is `-s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}} -X main.builtBy=goreleaser`.
    ldflags:
```