### PR TITLE
Fix Vault readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,10 +203,10 @@ The `auth_method` or `VAULT_AUTH_METHOD` envar configures how `vals` authenticat
 
 Examples:
 
-- `ref+vault://mykv/foo#/bar?address=https://vault1.example.com:8200` reads the value for the field `bar` in the kv `foo` on Vault listening on `https://vault1.example.com` with the Vault token read from **the envvar `VAULT_TOKEN`, or the file `~/.vault_token` when the envvar is not set**
-- `ref+vault://mykv/foo#/bar?token_env=VAULT_TOKEN_VAULT1&namespace=ns1&address=https://vault1.example.com:8200` reads the value for the field `bar` from namespace `ns1` in the kv `foo` on Vault listening on `https://vault1.example.com` with the Vault token read from **the envvar `VAULT_TOKEN_VAULT1`**
-- `ref+vault://mykv/foo#/bar?token_file=~/.vault_token_vault1&address=https://vault1.example.com:8200` reads the value for the field `bar` in the kv `foo` on Vault listening on `https://vault1.example.com` with the Vault token read from **the file `~/.vault_token_vault1`**
-- `ref+vault://mykv/foo#/bar?role_id=my-kube-role` using the Kubernetes role to log in to Vault
+- `ref+vault://mykv/foo?address=https://vault1.example.com:8200#/bar` reads the value for the field `bar` in the kv `foo` on Vault listening on `https://vault1.example.com` with the Vault token read from **the envvar `VAULT_TOKEN`, or the file `~/.vault_token` when the envvar is not set**
+- `ref+vault://mykv/foo?token_env=VAULT_TOKEN_VAULT1&namespace=ns1&address=https://vault1.example.com:8200#/bar` reads the value for the field `bar` from namespace `ns1` in the kv `foo` on Vault listening on `https://vault1.example.com` with the Vault token read from **the envvar `VAULT_TOKEN_VAULT1`**
+- `ref+vault://mykv/foo?token_file=~/.vault_token_vault1&address=https://vault1.example.com:8200#/bar` reads the value for the field `bar` in the kv `foo` on Vault listening on `https://vault1.example.com` with the Vault token read from **the file `~/.vault_token_vault1`**
+- `ref+vault://mykv/foo?role_id=my-kube-role#/bar` using the Kubernetes role to log in to Vault
 
 ### AWS
 


### PR DESCRIPTION
This PR may safe hours of debugging for someone like me

The example from readme dos not work. The error message should contain `vault1.example.com:8200` not ` 127.0.0.1:8200`
```
$ echo "a: ref+vault://mykv/foo#/bar?address=https://vault1.example.com:8200" | vals eval -f -
expand vault://mykv/foo#/bar?address=https://vault1.example.com:8200: Get "https://127.0.0.1:8200/v1/sys/internal/ui/mounts/mykv/foo": dial tcp 127.0.0.1:8200: connect: connection refused
```

New example works as expected the error message has `https://vault1.example.com:8200`.
````
$ echo "a: ref+vault://mykv/foo?address=https://vault1.example.com:8200#/bar" | vals eval -f -
expand vault://mykv/foo?address=https://vault1.example.com:8200#/bar: Get "https://vault1.example.com:8200/v1/sys/internal/ui/mounts/mykv/foo": dial tcp: lookup vault1.example.com on 127.0.0.53:53: no such host
```